### PR TITLE
Fix issue when table_cleaner_align_to_middle = true

### DIFF
--- a/table_cleaner.py
+++ b/table_cleaner.py
@@ -141,7 +141,7 @@ class TableCleanerCommand(table_commons.TextCommand):
                 if self.align_to_middle:
                     # Determine the number of characters that need to be
                     # inserted to left and to right
-                    l_diff = diff / 2
+                    l_diff = diff // 2
                     r_diff = diff - l_diff
 
                     # If the current column is the first column, do not insert


### PR DESCRIPTION
Issue:  "TypeError: can't multiply sequence by non-int of type 'float'"
Steps to reproduce: Try to align a table with `"table_cleaner_align_to_middle": true` 
Fix: Changed `l_diff = diff / 2` to `l_diff = diff // 2` (Python3)
