### PR TITLE
Allow right-aligning columns with numerical data

### DIFF
--- a/Base File.sublime-settings
+++ b/Base File.sublime-settings
@@ -6,6 +6,9 @@
   // aligned to left)
   "table_cleaner_align_to_middle": false,
 
+  // Align the text of each cell containing only numeric characters to the right
+  "table_cleaner_align_right_numeric": false,
+
   // The number of whitespaces between the text of a cell and the delimiters
   "table_cleaner_delimiter_spaces": 1,
 

--- a/Base File.sublime-settings
+++ b/Base File.sublime-settings
@@ -3,7 +3,7 @@
 	"table_cleaner_delimiters": ["|", "&", "\\\\"],
 
   // Align the text of each cell to middle (if set to false, the text will be
-  // alligned to left)
+  // aligned to left)
   "table_cleaner_align_to_middle": false,
 
   // The number of whitespaces between the text of a cell and the delimiters

--- a/README.markdown
+++ b/README.markdown
@@ -43,6 +43,7 @@ Align a table pasted from another source (e.g. a website).
 These settings can be found in Base File.sublime-settings
 - **table_cleaner_delimiters** - Delimiters between two cells of the table - default: **["|", "&", "\\\\"]**
 - **table_cleaner_align_to_middle** - Align the text of each cell to middle (if set to false, the text will be aligned to left) - default: **false**
+- **table_cleaner_align_right_numeric** - Align the text of each cell containing only numeric characters to the right - default: **false**
 - **table_cleaner_delimiters_white_spaces** - The number of whitespaces between the text of a cell and the delimiters - default: **1**
 - **table_import_separator** - The separator inserted when formatting a table imported - default: **"|"**
 - **table_import_sorround_with_separator** - Append a separator at the beginning and the end of each line when importing a table - default: **true**

--- a/README.markdown
+++ b/README.markdown
@@ -42,7 +42,7 @@ Align a table pasted from another source (e.g. a website).
 ## Settings
 These settings can be found in Base File.sublime-settings
 - **table_cleaner_delimiters** - Delimiters between two cells of the table - default: **["|", "&", "\\\\"]**
-- **table_cleaner_align_to_middle** - Align the text of each cell to middle (if set to false, the text will be alligned to left) - default: **false**
+- **table_cleaner_align_to_middle** - Align the text of each cell to middle (if set to false, the text will be aligned to left) - default: **false**
 - **table_cleaner_delimiters_white_spaces** - The number of whitespaces between the text of a cell and the delimiters - default: **1**
 - **table_import_separator** - The separator inserted when formatting a table imported - default: **"|"**
 - **table_import_sorround_with_separator** - Append a separator at the beginning and the end of each line when importing a table - default: **true**

--- a/table_cleaner.py
+++ b/table_cleaner.py
@@ -60,6 +60,9 @@ class TableCleanerCommand(table_commons.TextCommand):
         self.align_to_middle = (self.view.settings()
                                     .get('table_cleaner_align_to_middle',
                                          False))
+        self.align_right_numeric = (self.view.settings()
+                                        .get('table_cleaner_align_right_numeric',
+                                             False))
         self.delimiter_spaces = (self.view.settings()
                                      .get('table_cleaner_delimiter_spaces', 1))
 
@@ -121,6 +124,7 @@ class TableCleanerCommand(table_commons.TextCommand):
     # Perform the alignment
     def align(self, lines, orig_lines, front_whites):
         lines = self.split_lines(lines, self.SEPARATOR)
+        is_numeric = False
 
         # Find the sizes of the table
         rows_size = len(lines)
@@ -138,7 +142,25 @@ class TableCleanerCommand(table_commons.TextCommand):
 
                 diff = max_len - len(cell)
 
-                if self.align_to_middle:
+                if self.align_right_numeric:
+                    is_numeric = (cell.replace('$', '')
+                                      .replace('-', '')
+                                      .replace(',', '')
+                                      .replace('.', '')
+                                      .isdigit())
+
+                if is_numeric:
+                    if col == 0:
+                        cell = ((" " * diff) + cell +
+                                self.delimiter_spaces * " ")
+
+                        if cell == " ":
+                            cell = ""
+                    else:
+                        cell = (" " + (" " * diff) + cell +
+                                self.delimiter_spaces * " ")
+
+                elif self.align_to_middle:
                     # Determine the number of characters that need to be
                     # inserted to left and to right
                     l_diff = diff // 2

--- a/table_cleaner.py
+++ b/table_cleaner.py
@@ -7,7 +7,7 @@ import copy
 class TableCleanerCommand(table_commons.TextCommand):
     # Default separator, all the recognised separators being replaced with this
     # one, before aligning the tables, acting as an intermediate.
-    SEPARATOR = "&"
+    SEPARATOR = chr(7)
 
     def run(self, edit):
         self.edit = edit


### PR DESCRIPTION
Hi there, thanks for this great plugin! Working with Cucumber, we have a preference for right-aligning columns of text with numeric or monetary values, finding it looks neater and makes the tables more readable.

So, I've added an optional setting called `table_cleaner_align_right_numeric` which, when enabled, will automatically align any cells with numeric-only data (defined as only the integer characters 0-9, the dollar sign, comma, full stop and negative sign/hyphen) to the right side of the column.

Here's an example of a table formatted with the setting enabled:

```
Product    | Colour | Price   
apple      | red    |   $2.50 
watermelon | green  |  $12.00 
banana     | yellow |   $4.00 
iphone     | black  | $500.00 
```

While I was there, I also fixed the spelling of `aligned` (I wanted to also fix `surround` but didn't want to disrupt users that already have that setting configured themselves), and changed the "default separator" from `&` to a non-printable character so that tables with `&` in the text can be aligned correctly (provided that you use the `table_cleaner_delimiters` setting to exclude `&` from the possible delimiters).
