### PR TITLE
Do not use Alt as sole modifier on Mac

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,4 @@
 [
-  { "keys": ["alt+;"], "command": "table_cleaner" },
-  { "keys": ["alt+shift+;"], "command": "table_import" }
+  { "keys": ["ctrl+alt+;"], "command": "table_cleaner" },
+  { "keys": ["ctrl+alt+shift+;"], "command": "table_import" }
 ]


### PR DESCRIPTION
Using Alt interferes with keys for special letters.

Adresses #3